### PR TITLE
#20. set opened groups by default

### DIFF
--- a/js/components/toc/fragments/GroupTitle.jsx
+++ b/js/components/toc/fragments/GroupTitle.jsx
@@ -42,7 +42,7 @@ export class GroupTitle extends React.Component {
     };
 
     componentDidMount() {
-        this.props.setDefaultExpanded(this.props.node.id, {expanded: false});
+        this.props.setDefaultExpanded(this.props.node.id, {expanded: true});
     }
 
     render() {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Feature

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#20 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Groups are opened by default
## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
