### PR TITLE
#71 & #72: Add download option to layer setting and update styles

### DIFF
--- a/assets/themes/default/theme.less
+++ b/assets/themes/default/theme.less
@@ -190,3 +190,8 @@ element.style {
         height: 42px !important;
     }
 }
+
+.toc-toolbar-wrap {
+    display: flex;
+    flex-wrap: wrap;
+}

--- a/js/components/toc/DefaultLayer.less
+++ b/js/components/toc/DefaultLayer.less
@@ -15,8 +15,8 @@
         max-height: 200px;
         position: relative;
         text-align: center;
-        width: 180px;
-        
+        width: 175px;
+
         .toc-default-layer-head .toc-title {
             max-width: 120px;
             text-align: center;

--- a/js/components/toc/Toolbar.jsx
+++ b/js/components/toc/Toolbar.jsx
@@ -195,7 +195,9 @@ export class Toolbar extends React.Component {
                 <ReactCSSTransitionGroup
                     transitionName="toc-toolbar-btn-transition"
                     transitionEnterTimeout={300}
-                    transitionLeaveTimeout={300}>
+                    transitionLeaveTimeout={300}
+                    className="toc-toolbar-wrap"
+                >
                     {this.props.activateTool.activateAddLayer && (status === 'DESELECT' || status === 'GROUP') ?
                         <OverlayTrigger
                             key="addLayer"

--- a/js/plugins/TOC.jsx
+++ b/js/plugins/TOC.jsx
@@ -277,7 +277,7 @@ class LayerTree extends React.Component {
         activateRemoveLayer: true,
         activateRemoveGroup: true,
         activateQueryTool: true,
-        activateDownloadTool: false,
+        activateDownloadTool: true,
         activateWidgetTool: false,
         activateLayerFilterTool: false,
         maxDepth: 3,


### PR DESCRIPTION
## Description
This PR enable the option of download/exporting layer via layer's setting along with some minor styles updated

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Enhancement
 - [x] Minor styles update 

##Issue

**What is the current behavior?**
#71 #72 

**What is the new behavior?**
- Layer widget's size is reduced in order fit in the TOC 
- Added layer export button to layer's settings, using which user can export layer in all the supported format

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

## Other useful information
