### PR TITLE
#74: Legend via layer setting as popup

### DIFF
--- a/assets/themes/default/theme.less
+++ b/assets/themes/default/theme.less
@@ -195,3 +195,11 @@ element.style {
     display: flex;
     flex-wrap: wrap;
 }
+
+#legend-dialog {
+    margin-left: 450px;
+    @media screen and (min-width: 300px)
+    and (max-width: @screen-sm) {
+        margin: 200px 100px;
+    }
+}

--- a/js/components/modals/Legend.js
+++ b/js/components/modals/Legend.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import {Glyphicon} from 'react-bootstrap';
+import WMSLegend from '../../../MapStore2/web/client/components/TOC/fragments/WMSLegend';
+import Portal from '../../../MapStore2/web/client/components/misc/Portal';
+import Dialog from  '../../../MapStore2/web/client/components/misc/Dialog';
+import Message from "../../../MapStore2/web/client/components/I18N/Message";
+
+export default ({onClose, legendOptions}) => {
+    return (
+        <Portal>
+            <Dialog id={"legend-dialog"} draggable={false} style={{width: 300}} onClickOut={onClose} modal={false}>
+                <span role="header" style={{display: "flex", justifyContent: "space-between"}}>
+                    <span><Message msgId={"toc.legend.title"} /></span>
+                    <button onClick={onClose} className="close"> <Glyphicon glyph="1-close"/></button>
+                </span>
+                <div role="body">
+                    <WMSLegend {...legendOptions} />
+                </div>
+            </Dialog>
+        </Portal>
+    );
+};

--- a/js/components/toc/DefaultLayer.jsx
+++ b/js/components/toc/DefaultLayer.jsx
@@ -41,7 +41,6 @@ class DefaultLayer extends React.Component {
         onSelect: PropTypes.func,
         style: PropTypes.object,
         sortableStyle: PropTypes.object,
-        activateLegendTool: PropTypes.bool,
         activateOpacityTool: PropTypes.bool,
         indicators: PropTypes.array,
         visibilityCheckType: PropTypes.string,
@@ -77,7 +76,6 @@ class DefaultLayer extends React.Component {
         onToggle: () => {},
         onContextMenu: () => {},
         onSelect: () => {},
-        activateLegendTool: false,
         activateOpacityTool: true,
         indicators: [],
         visibilityCheckType: "glyph",
@@ -146,12 +144,6 @@ class DefaultLayer extends React.Component {
             <div key="legend" position="collapsible" className="collapsible-toc">
                 <Grid fluid>
                     {this.props.showFullTitleOnExpand ? <Row><Col xs={12} className="toc-full-title">{this.getTitle(this.props.node)}</Col></Row> : null}
-                    {this.props.activateLegendTool ?
-                        <Row>
-                            <Col xs={12}>
-                                <WMSLegend node={this.props.node} currentZoomLvl={this.props.currentZoomLvl} scales={this.props.scales} language={this.props.language} {...this.props.legendOptions} />
-                            </Col>
-                        </Row> : null}
                 </Grid>
                 {this.renderOpacitySlider(this.props.hideOpacityTooltip)}
             </div>);
@@ -229,7 +221,7 @@ class DefaultLayer extends React.Component {
     };
 
     renderNode = (grab, hide, selected, error, warning, isDummy, other) => {
-        const isEmpty = this.props.node.type === 'wms' && !this.props.activateLegendTool && !this.props.showFullTitleOnExpand
+        const isEmpty = this.props.node.type === 'wms' && !this.props.showFullTitleOnExpand
         || this.props.node.type !== 'wms' && !this.props.showFullTitleOnExpand;
         const head = (isDummy ?
             <div style={{padding: 0, height: 10}} className="toc-default-layer-head"/> :

--- a/js/components/toc/DefaultLayer.jsx
+++ b/js/components/toc/DefaultLayer.jsx
@@ -15,7 +15,6 @@ const Node = require('../../../MapStore2/web/client/components/TOC/Node');
 const draggableComponent = require('../../../MapStore2/web/client/components/TOC/enhancers/draggableComponent');
 const VisibilityCheck = require('../../../MapStore2/web/client/components/TOC/fragments/VisibilityCheck');
 const Title = require('../../../MapStore2/web/client/components/TOC/fragments/Title');
-const WMSLegend = require('../../../MapStore2/web/client/components/TOC/fragments/WMSLegend');
 const LayersTool = require('../../../MapStore2/web/client/components/TOC/fragments/LayersTool');
 const OpacitySlider = require('../../../MapStore2/web/client/components/TOC/fragments/OpacitySlider');
 const ToggleFilter = require('../../../MapStore2/web/client/components/TOC/fragments/ToggleFilter');

--- a/js/components/toc/Toolbar.jsx
+++ b/js/components/toc/Toolbar.jsx
@@ -17,6 +17,7 @@ import OverlayTrigger from '../../../MapStore2/web/client/components/misc/Overla
 import ConfirmModal from '../../../MapStore2/web/client/components/maps/modals/ConfirmModal';
 import LayerMetadataModal from '../../../MapStore2/web/client/components/TOC/fragments/LayerMetadataModal';
 import Message from '../../../MapStore2/web/client/components/I18N/Message';
+import Legend from "../modals/Legend";
 
 export class Toolbar extends React.Component {
 
@@ -34,6 +35,7 @@ export class Toolbar extends React.Component {
         layerMetadata: PropTypes.object,
         wfsdownload: PropTypes.object,
         maxDepth: PropTypes.number,
+        legendProps: PropTypes.object,
         metadataTemplate: PropTypes.oneOfType([PropTypes.string, PropTypes.array, PropTypes.object, PropTypes.func])
     };
 
@@ -327,7 +329,18 @@ export class Toolbar extends React.Component {
                             </Button>
                         </OverlayTrigger>
                         : null}
+                    {this.props.activateTool.activateLegendTool && (status === 'LAYER') && this.props.selectedLayers.length === 1 && this.props.selectedLayers[0].type === 'wms' && !this.props.settings.expanded && !this.props.layerMetadata.expanded && !this.props.wfsdownload.expanded ?
+                        <OverlayTrigger
+                            key="legend"
+                            placement="top"
+                            overlay={<Tooltip id="toc-tooltip-widgets">{this.props.text.legendTooltip}</Tooltip>}>
+                            <Button bsStyle="primary" className="square-button-md" onClick={()=>this.setState({showLegend: true})}>
+                                <Glyphicon glyph="th-list" />
+                            </Button>
+                        </OverlayTrigger>
+                        : null}
                 </ReactCSSTransitionGroup>
+                {this.state.showLegend && <Legend onClose={()=>this.setState({showLegend: false})} legendOptions={{node: this.props.selectedLayers[0], ...this.props.legendProps}} />}
                 <ConfirmModal
                     ref="removelayer"
                     options={{

--- a/js/plugins/TOC.jsx
+++ b/js/plugins/TOC.jsx
@@ -362,7 +362,6 @@ class LayerTree extends React.Component {
                 propertiesChangeHandler={this.props.layerPropertiesChangeHandler}
                 onSelect={this.props.activateToolsContainer ? this.props.onSelectNode : null}
                 visibilityCheckType={this.props.visibilityCheckType}
-                activateLegendTool={this.props.activateLegendTool}
                 currentZoomLvl={this.props.currentZoomLvl}
                 scales={this.props.scales}
                 currentLocale={this.props.currentLocale}
@@ -383,6 +382,12 @@ class LayerTree extends React.Component {
                         wfsdownload={this.props.wfsdownload}
                         metadataTemplate={this.props.metadataTemplate}
                         maxDepth={this.props.maxDepth}
+                        legendProps={{
+                            currentZoomLvl: this.props.currentZoomLvl,
+                            scales: this.props.scales,
+                            language: this.props.isLocalizedLayerStylesEnabled ? this.props.currentLocaleLanguage : null,
+                            legendOptions: {...this.props.layerOptions.legendOptions}
+                        }}
                         activateTool={{
                             activateToolsContainer: this.props.activateToolsContainer,
                             activateRemoveLayer: this.props.activateRemoveLayer,
@@ -393,7 +398,8 @@ class LayerTree extends React.Component {
                             includeDeleteButtonInSettings: false,
                             activateMetedataTool: this.props.activateMetedataTool,
                             activateWidgetTool: this.props.activateWidgetTool,
-                            activateLayerFilterTool: this.props.activateLayerFilterTool
+                            activateLayerFilterTool: this.props.activateLayerFilterTool,
+                            activateLegendTool: this.props.activateLegendTool
                         }}
                         options={{
                             modalOptions: {},
@@ -442,7 +448,8 @@ class LayerTree extends React.Component {
                             },
                             layerMetadataTooltip: <Message msgId="toc.layerMetadata.toolLayerMetadataTooltip"/>,
                             layerMetadataPanelTitle: <Message msgId="toc.layerMetadata.layerMetadataPanelTitle"/>,
-                            layerFilterTooltip: <Message msgId="toc.layerFilterTooltip"/>
+                            layerFilterTooltip: <Message msgId="toc.layerFilterTooltip"/>,
+                            legendTooltip: <Message msgId="toc.legend.tooltip"/>
 
                         }}
                         onToolsActions={{

--- a/localConfig.json
+++ b/localConfig.json
@@ -281,7 +281,7 @@
           "activateLayerFilterTool":false,
           "activateQueryTool":false,
           "activateFilterLayer": false,
-          "activateLegendTool": false
+          "activateLegendTool": true
         }
       },
       "AddGroup",
@@ -477,7 +477,7 @@
         "cfg":{
           "activateMetedataTool":false,
           "activateFilterLayer": false,
-          "activateLegendTool": false,
+          "activateLegendTool": true,
           "layerOptions":{
             "legendOptions":{
               "WMSLegendOptions":"forceLabels:on",

--- a/translations/data.en-US.json
+++ b/translations/data.en-US.json
@@ -2,7 +2,6 @@
   "locale": "en-US",
   "messages": {
     "home": {
-	
       "title": "NATIONAL FOREST<br/>MONITORING SYSTEM PORTAL",
       "country": "DEMOCRATIC REPUBLIC OF CONGO",
       "institute": "MINISTRY OF THE ENVIRONMENT AND SUSTAINABLE DEVELOPMENT",
@@ -16,7 +15,11 @@
     },
     "toc": {
       "settingsPopup": "Settings",
-      "thumbnail": "Thumbnail"
+      "thumbnail": "Thumbnail",
+      "legend": {
+        "title": "Legend",
+        "tooltip": "Show Legend"
+      }
     }
   }
 }

--- a/translations/data.fr-FR.json
+++ b/translations/data.fr-FR.json
@@ -15,7 +15,11 @@
       },
       "toc": {
         "settingsPopup": "Paramètres",
-        "thumbnail": "La vignette"
+        "thumbnail": "La vignette",
+        "legend": {
+          "title": "Légende",
+          "tooltip": "Afficher les légende"
+        }
       }
     }
   }


### PR DESCRIPTION
## Description
This PR adds the feature of viewing layer's legend in a modal via the layer tools

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Enhancement

##Issue

**What is the current behavior?**
#74 

**What is the new behavior?**
The legend is accessible via the layer settings tool
![2021-04-14 19_24_21-MapStore 2 project for FAO - Democratic Republic of the Congo](https://user-images.githubusercontent.com/26929983/114721964-06fea780-9d57-11eb-8a9c-3867cae198ed.jpg)


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

## Other useful information
